### PR TITLE
New variables and small fixes

### DIFF
--- a/L1Trigger/L1TMuonOverlapPhase1/interface/Tools/DataROOTDumper2.h
+++ b/L1Trigger/L1TMuonOverlapPhase1/interface/Tools/DataROOTDumper2.h
@@ -31,7 +31,7 @@ public:
 
   //muonPt = 0 means that no muon was matched to the candidate
   short muonEvent = -1;
-  float muonPt = 0, muonEta = 0, muonPhi = 0;
+  float muonPt = 0, muonEta = 0, muonPhi = 0, muonPropEta = 0, muonPropPhi = 0;
   char muonCharge = 0;
   float muonDxy = 0;
   float muonRho = 0;
@@ -50,6 +50,8 @@ public:
   unsigned int omtfFiredLayers = 0;
 
   bool killed = false;
+
+  float deltaPhi = 0, deltaEta = 0;
 
   //float omtfPtCont = 0;
 

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/CandidateSimMuonMatcher.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/CandidateSimMuonMatcher.cc
@@ -636,7 +636,7 @@ std::vector<MatchingResult> CandidateSimMuonMatcher::match(std::vector<const l1t
         }
         int vtxInd = simTrack.vertIndex();
         if (vtxInd >= 0) {
-          //result.simVertex = &(simVertices->at(vtxInd)); //TODO ?????? something strange is here, was commented in the previous version
+          result.simVertex = &(simVertices->at(vtxInd)); //TODO ?????? something strange is here, was commented in the previous version
         }
         if (result.result == MatchingResult::ResultType::matched) {
           matchingResults.push_back(result);

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/DataROOTDumper2.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/DataROOTDumper2.cc
@@ -68,6 +68,7 @@ void DataROOTDumper2::initializeTTree(std::string rootFileName) {
   rootTree->Branch("muonRho", &omtfEvent.muonRho);
 
   rootTree->Branch("omtfPt", &omtfEvent.omtfPt);
+  rootTree->Branch("omtfUncPt", &omtfEvent.omtfUncPt);
   rootTree->Branch("omtfEta", &omtfEvent.omtfEta);
   rootTree->Branch("omtfPhi", &omtfEvent.omtfPhi);
   rootTree->Branch("omtfCharge", &omtfEvent.omtfCharge);
@@ -229,6 +230,7 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
 
     auto addOmtfCand = [&](AlgoMuonPtr& procMuon) {
       omtfEvent.omtfPt = omtfConfig->hwPtToGev(procMuon->getPt());
+      omtfEvent.omtfUncPt = omtfConfig->hwPtToGev(procMuon->getPtUnconstrained());
       omtfEvent.omtfEta = omtfConfig->hwEtaToEta(procMuon->getEtaHw());
       omtfEvent.omtfPhi = procMuon->getPhi();
       omtfEvent.omtfCharge = procMuon->getCharge();
@@ -333,6 +335,7 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
       LogTrace("l1tOmtfEventPrint") << "DataROOTDumper2::observeEventEnd no matching omtfCand" << std::endl;
 
       omtfEvent.omtfPt = 0;
+      omtfEvent.omtfUncPt = 0;
       omtfEvent.omtfEta = 0;
       omtfEvent.omtfPhi = 0;
       omtfEvent.omtfCharge = 0;

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/DataROOTDumper2.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/DataROOTDumper2.cc
@@ -60,6 +60,8 @@ void DataROOTDumper2::initializeTTree(std::string rootFileName) {
   rootTree->Branch("muonPt", &omtfEvent.muonPt);
   rootTree->Branch("muonEta", &omtfEvent.muonEta);
   rootTree->Branch("muonPhi", &omtfEvent.muonPhi);
+  rootTree->Branch("muonPropEta", &omtfEvent.muonPropEta);
+  rootTree->Branch("muonPropPhi", &omtfEvent.muonPropPhi);
   rootTree->Branch("muonCharge", &omtfEvent.muonCharge);
 
   rootTree->Branch("muonDxy", &omtfEvent.muonDxy);
@@ -83,6 +85,9 @@ void DataROOTDumper2::initializeTTree(std::string rootFileName) {
   rootTree->Branch("killed", &omtfEvent.killed);
   
   rootTree->Branch("hits", &omtfEvent.hits);
+
+  rootTree->Branch("deltaEta", &omtfEvent.deltaEta);
+  rootTree->Branch("deltaPhi", &omtfEvent.deltaPhi);
 
   ptGenPos = fs->make<TH1I>("ptGenPos", "ptGenPos, eta at vertex 0.8 - 1.24", 400, 0, 200); //TODO
   ptGenNeg = fs->make<TH1I>("ptGenNeg", "ptGenNeg, eta at vertex 0.8 - 1.24", 400, 0, 200);
@@ -144,14 +149,18 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
 
       omtfEvent.muonPt = trackingParticle->pt();
       omtfEvent.muonEta = trackingParticle->momentum().eta();
-
       omtfEvent.muonPhi = trackingParticle->momentum().phi();
+      omtfEvent.muonPropEta = matchingResult.propagatedEta;
+      omtfEvent.muonPropPhi = matchingResult.propagatedPhi;
       omtfEvent.muonCharge = (abs(trackingParticle->pdgId()) == 13) ? trackingParticle->pdgId() / -13 : 0;;  //TODO
 
-      //omtfEvent.muonDxy = TODO
-      if(trackingParticle->parentVertex().isNonnull())
+      if(trackingParticle->parentVertex().isNonnull()) {
+        omtfEvent.muonDxy = trackingParticle->dxy();
         omtfEvent.muonRho = trackingParticle->parentVertex()->position().Rho();
+      }
 
+      omtfEvent.deltaEta = matchingResult.deltaEta;
+      omtfEvent.deltaPhi = matchingResult.deltaPhi;
 
       LogTrace("l1tOmtfEventPrint") << "DataROOTDumper2::observeEventEnd trackingParticle: eventId " << trackingParticle->eventId().event() << " pdgId " << std::setw(3)
                  << trackingParticle->pdgId() << " trackId " << trackingParticle->g4Tracks().at(0).trackId() << " pt "
@@ -173,13 +182,19 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
 
       omtfEvent.muonPt = simTrack->momentum().pt();
       omtfEvent.muonEta = simTrack->momentum().eta();
-
       omtfEvent.muonPhi = simTrack->momentum().phi();
-      omtfEvent.muonCharge = (abs(simTrack->type()) == 13) ? simTrack->type() / -13 : 0;;  //TODO
+      omtfEvent.muonPropEta = matchingResult.propagatedEta;
+      omtfEvent.muonPropPhi = matchingResult.propagatedPhi;
+      omtfEvent.muonCharge = simTrack->charge();
 
-      //omtfEvent.muonDxy = TODO
-      //if(trackingParticle->parentVertex().isNonnull()) //TODO!!!!!!!!!!!!!!!!!!
-      //  omtfEvent.muonRho = trackingParticle->parentVertex()->position().Rho();
+      if (!simTrack->noVertex() && matchingResult.simVertex) {
+	const math::XYZTLorentzVectorD& vtxPos = matchingResult.simVertex->position();
+	omtfEvent.muonDxy = (-vtxPos.X() * simTrack->momentum().py() + vtxPos.Y() * simTrack->momentum().px()) / simTrack->momentum().pt();
+	omtfEvent.muonRho = vtxPos.Rho();
+      }
+
+      omtfEvent.deltaEta = matchingResult.deltaEta;
+      omtfEvent.deltaPhi = matchingResult.deltaPhi;
 
       LogTrace("l1tOmtfEventPrint") << "DataROOTDumper2::observeEventEnd trackingParticle: eventId " << simTrack->eventId().event() << " pdgId " << std::setw(3)
                  << simTrack->type() //<< " trackId " << simTrack->g4Tracks().at(0).trackId()
@@ -198,9 +213,13 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
       omtfEvent.muonEvent = -1;
 
       omtfEvent.muonPt = 0;
-      omtfEvent.muonEta = 0;
 
+      omtfEvent.muonEta = 0;
       omtfEvent.muonPhi = 0;
+
+      omtfEvent.muonPropEta = 0;
+      omtfEvent.muonPropPhi = 0;
+
       omtfEvent.muonCharge = 0;  //TODO
 
       omtfEvent.muonDxy = 0;


### PR DESCRIPTION
Jak w tytule: dodanie kilku zmiennych do drzew produkowanych przez OMTF DataROOTDumper2 + kilka małych proprawek. m.in. obliczanie i zapisywanie dxy i rho dla matchowania z simTrack-ami. Przetestowane z powodzeniem na hiszpańskich próbkach displaced. 