### PR TITLE
Partial cleaning and other small changes towards integration with offcial CMSSW (v2)

### DIFF
--- a/L1Trigger/L1TMuonOverlapPhase1/interface/Tools/DataROOTDumper2.h
+++ b/L1Trigger/L1TMuonOverlapPhase1/interface/Tools/DataROOTDumper2.h
@@ -96,8 +96,7 @@ public:
   void endJob() override;
 
 private:
-  void initializeTTree(std::string rootFileName);
-  void saveTTree();
+  void initializeTTree();
 
   CandidateSimMuonMatcher* candidateSimMuonMatcher = nullptr;
 

--- a/L1Trigger/L1TMuonOverlapPhase1/python/simOmtfDigis_cfi.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/python/simOmtfDigis_cfi.py
@@ -2,28 +2,28 @@ import FWCore.ParameterSet.Config as cms
 
 ###OMTF emulator configuration
 simOmtfDigis = cms.EDProducer("L1TMuonOverlapPhase1TrackProducer",
-                              
+
   srcDTPh = cms.InputTag('simDtTriggerPrimitiveDigis'),
   srcDTTh = cms.InputTag('simDtTriggerPrimitiveDigis'),
   srcCSC = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
-  srcRPC = cms.InputTag('simMuonRPCDigis'), 
-  
-  #g4SimTrackSrc = cms.InputTag('g4SimHits'),                             
+  srcRPC = cms.InputTag('simMuonRPCDigis'),
+
+  #g4SimTrackSrc = cms.InputTag('g4SimHits'),
   dumpResultToXML = cms.bool(False),
   dumpDetailedResultToXML = cms.bool(False),
-  XMLDumpFileName = cms.string("TestEvents.xml"),                                     
-  dumpGPToXML = cms.bool(False),  
+  XMLDumpFileName = cms.string("TestEvents.xml"),
+  dumpGPToXML = cms.bool(False),
   readEventsFromXML = cms.bool(False),
   eventsXMLFiles = cms.vstring("TestEvents.xml"),
-  dropRPCPrimitives = cms.bool(False),                                    
-  dropDTPrimitives = cms.bool(False),                                    
+  dropRPCPrimitives = cms.bool(False),
+  dropDTPrimitives = cms.bool(False),
   dropCSCPrimitives = cms.bool(False),
-  processorType = cms.string("OMTFProcessor"),  
+  processorType = cms.string("OMTFProcessor"),
 
   #ghostBusterType = cms.string("GhostBusterPreferRefDt"),
-  
+
   #patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_0x00020007.xml")
-  #patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_0x0003.xml")                               
+  #patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_0x0003.xml")
 
   #if commented the default values are 0-0
   #-3 to 4 is the range of the OMTF DAQ readout, so should be used e.g. in the DQM data to emulator comparison

--- a/L1Trigger/L1TMuonOverlapPhase1/python/simOmtfDigis_extrapolSimple_cfi.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/python/simOmtfDigis_extrapolSimple_cfi.py
@@ -1,51 +1,24 @@
 import FWCore.ParameterSet.Config as cms
 
-###OMTF emulator configuration
-simOmtfDigis = cms.EDProducer("L1TMuonOverlapPhase1TrackProducer",
+###OMTF emulator configuration with simple extrapolation algorithm
+from L1Trigger.L1TMuonOverlapPhase1.simOmtfDigis_cfi import simOmtfDigis
 
-  srcDTPh = cms.InputTag('simDtTriggerPrimitiveDigis'),
-  srcDTTh = cms.InputTag('simDtTriggerPrimitiveDigis'),
-  srcCSC = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
-  srcRPC = cms.InputTag('simMuonRPCDigis'),
+## add parameters to enable simple extrapolation algorithm
+simOmtfDigis.noHitValueInPdf = cms.bool(True)
+simOmtfDigis.minDtPhiQuality = cms.int32(2)
+simOmtfDigis.minDtPhiBQuality = cms.int32(4)
 
-  #g4SimTrackSrc = cms.InputTag('g4SimHits'),
-  dumpResultToXML = cms.bool(False),
-  dumpDetailedResultToXML = cms.bool(False),
-  XMLDumpFileName = cms.string("TestEvents.xml"),
-  dumpGPToXML = cms.bool(False),
-  readEventsFromXML = cms.bool(False),
-  eventsXMLFiles = cms.vstring("TestEvents.xml"),
-  dropRPCPrimitives = cms.bool(False),
-  dropDTPrimitives = cms.bool(False),
-  dropCSCPrimitives = cms.bool(False),
-  processorType = cms.string("OMTFProcessor"),
+simOmtfDigis.dtRefHitMinQuality = cms.int32(4)
 
-  #ghostBusterType = cms.string("GhostBusterPreferRefDt"),
+simOmtfDigis.stubEtaEncoding = cms.string("bits")
 
-  #patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_0x00020007.xml")
-  #patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_0x0003.xml")
+simOmtfDigis.usePhiBExtrapolationFromMB1 = cms.bool(True)
+simOmtfDigis.usePhiBExtrapolationFromMB2 = cms.bool(True)
+simOmtfDigis.useStubQualInExtr = cms.bool(False)
+simOmtfDigis.useEndcapStubsRInExtr = cms.bool(False)
+simOmtfDigis.useFloatingPointExtrapolation = cms.bool(False)
 
-  #if commented the default values are 0-0
-  #-3 to 4 is the range of the OMTF DAQ readout, so should be used e.g. in the DQM data to emulator comparison
-  bxMin = cms.int32(0),
-  bxMax = cms.int32(0),
-
-  noHitValueInPdf = cms.bool(True),
-  minDtPhiQuality = cms.int32(2),
-  minDtPhiBQuality = cms.int32(4),
-
-  dtRefHitMinQuality = cms.int32(4),
-
-  stubEtaEncoding = cms.string("bits"),
-
-  usePhiBExtrapolationFromMB1 = cms.bool(True),
-  usePhiBExtrapolationFromMB2 = cms.bool(True),
-  useStubQualInExtr = cms.bool(False),
-  useEndcapStubsRInExtr = cms.bool(False),
-  useFloatingPointExtrapolation = cms.bool(False),
-
-  extrapolFactorsFilename = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/ExtrapolationFactors_simple.xml"),
-  sorterType = cms.string("byLLH"),
-  ghostBusterType = cms.string("byRefLayer"), # byLLH byRefLayer GhostBusterPreferRefDt
-  goldenPatternResultFinalizeFunction = cms.int32(10)
-)
+simOmtfDigis.extrapolFactorsFilename = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/ExtrapolationFactors_simple.xml")
+simOmtfDigis.sorterType = cms.string("byLLH")
+simOmtfDigis.ghostBusterType = cms.string("byRefLayer") # byLLH byRefLayer GhostBusterPreferRefDt
+simOmtfDigis.goldenPatternResultFinalizeFunction = cms.int32(10)

--- a/L1Trigger/L1TMuonOverlapPhase1/python/simOmtfDigis_extrapolSimple_cfi.py
+++ b/L1Trigger/L1TMuonOverlapPhase1/python/simOmtfDigis_extrapolSimple_cfi.py
@@ -2,51 +2,50 @@ import FWCore.ParameterSet.Config as cms
 
 ###OMTF emulator configuration
 simOmtfDigis = cms.EDProducer("L1TMuonOverlapPhase1TrackProducer",
-                              
+
   srcDTPh = cms.InputTag('simDtTriggerPrimitiveDigis'),
   srcDTTh = cms.InputTag('simDtTriggerPrimitiveDigis'),
   srcCSC = cms.InputTag('simCscTriggerPrimitiveDigis','MPCSORTED'),
-  srcRPC = cms.InputTag('simMuonRPCDigis'), 
-  
-  #g4SimTrackSrc = cms.InputTag('g4SimHits'),                             
+  srcRPC = cms.InputTag('simMuonRPCDigis'),
+
+  #g4SimTrackSrc = cms.InputTag('g4SimHits'),
   dumpResultToXML = cms.bool(False),
   dumpDetailedResultToXML = cms.bool(False),
-  XMLDumpFileName = cms.string("TestEvents.xml"),                                     
-  dumpGPToXML = cms.bool(False),  
+  XMLDumpFileName = cms.string("TestEvents.xml"),
+  dumpGPToXML = cms.bool(False),
   readEventsFromXML = cms.bool(False),
   eventsXMLFiles = cms.vstring("TestEvents.xml"),
-  dropRPCPrimitives = cms.bool(False),                                    
-  dropDTPrimitives = cms.bool(False),                                    
+  dropRPCPrimitives = cms.bool(False),
+  dropDTPrimitives = cms.bool(False),
   dropCSCPrimitives = cms.bool(False),
   processorType = cms.string("OMTFProcessor"),
-  
+
   #ghostBusterType = cms.string("GhostBusterPreferRefDt"),
-  
+
   #patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_0x00020007.xml")
-  #patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_0x0003.xml")                               
+  #patternsXMLFile = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/Patterns_0x0003.xml")
 
   #if commented the default values are 0-0
   #-3 to 4 is the range of the OMTF DAQ readout, so should be used e.g. in the DQM data to emulator comparison
   bxMin = cms.int32(0),
   bxMax = cms.int32(0),
-  
+
   noHitValueInPdf = cms.bool(True),
   minDtPhiQuality = cms.int32(2),
   minDtPhiBQuality = cms.int32(4),
-  
-  dtRefHitMinQuality =  cms.int32(4),
-    
+
+  dtRefHitMinQuality = cms.int32(4),
+
   stubEtaEncoding = cms.string("bits"),
-  
+
   usePhiBExtrapolationFromMB1 = cms.bool(True),
   usePhiBExtrapolationFromMB2 = cms.bool(True),
-  useStubQualInExtr  = cms.bool(False),
-  useEndcapStubsRInExtr  = cms.bool(False),
-  useFloatingPointExtrapolation  = cms.bool(False),
+  useStubQualInExtr = cms.bool(False),
+  useEndcapStubsRInExtr = cms.bool(False),
+  useFloatingPointExtrapolation = cms.bool(False),
 
-  extrapolFactorsFilename= cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/ExtrapolationFactors_simple.xml"),
+  extrapolFactorsFilename = cms.FileInPath("L1Trigger/L1TMuon/data/omtf_config/ExtrapolationFactors_simple.xml"),
   sorterType = cms.string("byLLH"),
   ghostBusterType = cms.string("byRefLayer"), # byLLH byRefLayer GhostBusterPreferRefDt
   goldenPatternResultFinalizeFunction = cms.int32(10)
 )
-

--- a/L1Trigger/L1TMuonOverlapPhase1/src/AngleConverterBase.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/AngleConverterBase.cc
@@ -103,8 +103,8 @@ int AngleConverterBase::getProcessorPhi(
   const CSCLayer* layer = chamber->layer(3);
   int order = (layer->centerOfStrip(2).phi() - layer->centerOfStrip(1).phi() > 0) ? 1 : -1;
   double stripPhiPitch = cspec->stripPhiPitch();
-  double scale = fabs(stripPhiPitch / hsPhiPitch / 2.);
-  if (fabs(scale - 1.) < 0.0002)
+  double scale = std::abs(stripPhiPitch / hsPhiPitch / 2.);
+  if (std::abs(scale - 1.) < 0.0002)
     scale = 1.;
 
   double phiHalfStrip0 = layer->centerOfStrip(1).phi() - order * stripPhiPitch / 4.;
@@ -175,7 +175,7 @@ int AngleConverterBase::getProcessorPhi(
   double stripPhi2 = (roll->toGlobal(roll->centreOfStrip((int)digi2))).phi();  // note [-pi,pi]
 
   // the case when the two strips are on different sides of phi = pi
-  if (std::signbit(stripPhi1) != std::signbit(stripPhi2) && fabs(stripPhi1) > M_PI / 2.) {
+  if (std::signbit(stripPhi1) != std::signbit(stripPhi2) && std::abs(stripPhi1) > M_PI / 2.) {
     if (std::signbit(stripPhi1)) {  //stripPhi1 is negative
       stripPhi1 += 2 * M_PI;
     } else  //stripPhi2 is negative
@@ -241,7 +241,7 @@ EtaValue AngleConverterBase::getGlobalEtaDt(const DTChamberId& detId) const {
 
   EtaValue etaValue = {
       config->etaToHwEta(chamberMiddleGP.eta()),
-      config->etaToHwEta(fabs(chamberMiddleGP.eta() - chambNeighMiddleGP.eta())) / 2,
+      config->etaToHwEta(std::abs(chamberMiddleGP.eta() - chambNeighMiddleGP.eta())) / 2,
       0,  //quality
       0,  //bx
       0   //timin
@@ -393,8 +393,8 @@ EtaValue AngleConverterBase::getGlobalEta(unsigned int rawid, const unsigned int
   int neighbRoll = 1;  //neighbor roll in eta
   //roll->chamber()->nrolls() does not work
   if (id.region() == 0) {  //barel
-    if (id.station() == 2 &&
-        ((abs(id.ring()) == 2 && id.layer() == 2) || (abs(id.ring()) != 2 && id.layer() == 1))) {  //three-roll chamber
+    if (id.station() == 2 && ((std::abs(id.ring()) == 2 && id.layer() == 2) ||
+                              (std::abs(id.ring()) != 2 && id.layer() == 1))) {  //three-roll chamber
       if (id.roll() == 2)
         neighbRoll = 1;
       else {
@@ -416,7 +416,7 @@ EtaValue AngleConverterBase::getGlobalEta(unsigned int rawid, const unsigned int
   const GlobalPoint gpNeigh = rollNeigh->toGlobal(lpNeigh);
 
   EtaValue etaValue = {config->etaToHwEta(gp.eta()),
-                       config->etaToHwEta(fabs(gp.eta() - gpNeigh.eta())) /
+                       config->etaToHwEta(std::abs(gp.eta() - gpNeigh.eta())) /
                            2,  //half of the size of the strip in eta - not precise, but OK
                        0};
 

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/GoldenPatternBase.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Omtf/GoldenPatternBase.cc
@@ -64,8 +64,8 @@ StubResult GoldenPatternBase::process1Layer1RefLayer(unsigned int iRefLayer,
     phiRefHit = 0;  //phi ref hit for the bending layer set to 0, since it should not be included in the phiDist
   }
 
-  for (unsigned int iStub = 0; iStub < layerStubs.size(); iStub++) {
-    auto& stub = layerStubs[iStub];
+  for (size_t iStub = 0; iStub < layerStubs.size(); iStub++) {
+    const auto& stub = layerStubs[iStub];
     if (!stub)  //empty pointer
       continue;
 
@@ -86,13 +86,13 @@ StubResult GoldenPatternBase::process1Layer1RefLayer(unsigned int iRefLayer,
     		<<"  iRefLayer "<<iRefLayer<<" iLayer "<<iLayer
     		<<" hitPhi "<<hitPhi<<" phiMean "<<phiMean<<" phiRefHit "<<phiRefHit<<" phiDist "<<phiDist<<std::endl;*/
 
-    //firmware works on the sign-value, shift must be done on abs(phiDist)
+    //firmware works on the sign-value, shift must be done on std::abs(phiDist)
     int sign = phiDist < 0 ? -1 : 1;
-    phiDist = abs(phiDist) >> this->getDistPhiBitShift(iLayer, iRefLayer);
+    phiDist = std::abs(phiDist) >> this->getDistPhiBitShift(iLayer, iRefLayer);
     phiDist *= sign;
     //if the shift is done here, it means that the phiMean in the xml should be the same as without shift
     //if (this->getDistPhiBitShift(iLayer, iRefLayer) != 0) std::cout<<__FUNCTION__<<":"<<__LINE__<<" phiDist "<<phiDist<<std::endl;
-    if (abs(phiDist) < abs(phiDistMin)) {
+    if (std::abs(phiDist) < std::abs(phiDistMin)) {
       phiDistMin = phiDist;
       selectedStub = stub;
     }
@@ -114,7 +114,7 @@ StubResult GoldenPatternBase::process1Layer1RefLayer(unsigned int iRefLayer,
 
   ///Check if phiDistMin is within pdf range -63 +63
   ///in firmware here the arithmetic "value and sign" is used, therefore the range is -63 +63, and not -64 +63
-  if (abs(phiDistMin) > ((1 << (myOmtfConfig->nPdfAddrBits() - 1)) - 1)) {
+  if (std::abs(phiDistMin) > ((1 << (myOmtfConfig->nPdfAddrBits() - 1)) - 1)) {
     return StubResult(0, false, phiDistMin + pdfMiddle, iLayer, selectedStub);
 
     //return GoldenPatternResult::LayerResult(this->pdfValue(iLayer, iRefLayer, 0), false, phiDistMin + pdfMiddle, selHit);

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/CandidateSimMuonMatcher.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/CandidateSimMuonMatcher.cc
@@ -87,7 +87,8 @@ void CandidateSimMuonMatcher::observeProcesorEmulation(unsigned int iProcessor,
 }
 
 bool simTrackIsMuonInOmtf(const SimTrack& simTrack) {
-  if (abs(simTrack.type()) == 13 || abs(simTrack.type()) == 1000015) {  //|| tpPtr->pt() > 20 //todo 1000015 is stau
+  if (std::abs(simTrack.type()) == 13 ||
+      std::abs(simTrack.type()) == 1000015) {  //|| tpPtr->pt() > 20 //todo 1000015 is stau
     //only muons
   } else
     return false;
@@ -103,8 +104,8 @@ bool simTrackIsMuonInOmtf(const SimTrack& simTrack) {
 
   //higher margin for matching must be used than actual OMTF region (i.e. 0.82 - 1.24),
   //otherwise many candidates are marked as ghosts
-  //if( (fabs(simTrack.momentum().eta()) >= 0.82 ) && (fabs(simTrack.momentum().eta()) <= 1.24) ) {
-  if ((fabs(simTrack.momentum().eta()) >= 0.72) && (fabs(simTrack.momentum().eta()) <= 1.3)) {
+  //if( (std::abs(simTrack.momentum().eta()) >= 0.82 ) && (std::abs(simTrack.momentum().eta()) <= 1.24) ) {
+  if ((std::abs(simTrack.momentum().eta()) >= 0.72) && (std::abs(simTrack.momentum().eta()) <= 1.3)) {
   } else
     return false;
 
@@ -119,7 +120,8 @@ bool simTrackIsMuonInOmtfBx0(const SimTrack& simTrack) {
 }
 
 bool simTrackIsMuonInBx0(const SimTrack& simTrack) {
-  if (abs(simTrack.type()) == 13 || abs(simTrack.type()) == 1000015) {  //|| tpPtr->pt() > 20 //todo 1000015 is stau
+  if (std::abs(simTrack.type()) == 13 ||
+      std::abs(simTrack.type()) == 1000015) {  //|| tpPtr->pt() > 20 //todo 1000015 is stau
     //only muons
     if (simTrack.eventId().bunchCrossing() == 0)
       return true;
@@ -128,8 +130,8 @@ bool simTrackIsMuonInBx0(const SimTrack& simTrack) {
 }
 
 bool trackingParticleIsMuonInBx0(const TrackingParticle& trackingParticle) {
-  if (abs(trackingParticle.pdgId()) == 13 ||
-      abs(trackingParticle.pdgId()) == 1000015) {  //|| tpPtr->pt() > 20 //todo 1000015 is stau
+  if (std::abs(trackingParticle.pdgId()) == 13 ||
+      std::abs(trackingParticle.pdgId()) == 1000015) {  //|| tpPtr->pt() > 20 //todo 1000015 is stau
     //only muons
     if (trackingParticle.eventId().bunchCrossing() == 0)
       return true;
@@ -146,7 +148,7 @@ bool trackingParticleIsMuonInOmtfBx0(const TrackingParticle& trackingParticle) {
   if (trackingParticle.eventId().bunchCrossing() != 0)
     return false;
 
-  if (abs(trackingParticle.pdgId()) == 13 || abs(trackingParticle.pdgId()) == 1000015) {
+  if (std::abs(trackingParticle.pdgId()) == 13 || std::abs(trackingParticle.pdgId()) == 1000015) {
     // 1000015 is stau, todo use other selection if needed
     //only muons
   } else
@@ -175,8 +177,8 @@ bool trackingParticleIsMuonInOmtfBx0(const TrackingParticle& trackingParticle) {
 
   //higher margin for matching must be used than actual OMTF region (i.e. 0.82 - 1.24),
   //otherwise many candidates are marked as ghosts
-  //if( (fabs(simTrack.momentum().eta()) >= 0.82 ) && (fabs(trackingParticle.momentum().eta()) <= 1.24) ) {
-  if ((fabs(trackingParticle.momentum().eta()) >= 0.72) && (fabs(trackingParticle.momentum().eta()) <= 1.3)) {
+  //if( (std::abs(simTrack.momentum().eta()) >= 0.82 ) && (std::abs(trackingParticle.momentum().eta()) <= 1.24) ) {
+  if ((std::abs(trackingParticle.momentum().eta()) >= 0.72) && (std::abs(trackingParticle.momentum().eta()) <= 1.3)) {
   } else
     return false;
 
@@ -255,7 +257,7 @@ std::vector<const l1t::RegionalMuonCand*> CandidateSimMuonMatcher::ghostBust(
       if (mtfCand2.hwPt() == 0)
         continue;
 
-      if (abs(mtfCand1.hwEta() - mtfCand2.hwEta()) < (0.3 / 0.010875)) {
+      if (std::abs(mtfCand1.hwEta() - mtfCand2.hwEta()) < (0.3 / 0.010875)) {
         int gloablHwPhi1 = omtfConfig->calcGlobalPhi(mtfCand1.hwPhi(), mtfCand1.processor());
         int gloablHwPhi2 = omtfConfig->calcGlobalPhi(mtfCand2.hwPhi(), mtfCand2.processor());
 
@@ -264,7 +266,7 @@ std::vector<const l1t::RegionalMuonCand*> CandidateSimMuonMatcher::ghostBust(
         //double globalPhi2 = hwGmtPhiToGlobalPhi(omtfConfig->calcGlobalPhi( mtfCand2.hwPhi(), mtfCand2.processor() ) );
 
         //0.0872664626 = 5 deg, i.e. the same window as in the OMTF ghost buster
-        if (abs(gloablHwPhi1 - gloablHwPhi2) < 8) {
+        if (std::abs(gloablHwPhi1 - gloablHwPhi2) < 8) {
           //if (mtfCand1.hwQual() > mtfCand2.hwQual()) //TODO this is used in the uGMT
           if (gbCandidates[i1]->getFiredLayerCnt() >
               gbCandidates[i2]->getFiredLayerCnt())  //but this should be better - but probably the difference is not big
@@ -393,7 +395,7 @@ MatchingResult CandidateSimMuonMatcher::match(const l1t::RegionalMuonCand* muonC
   MatchingResult result(simTrack);
 
   double candGloablEta = muonCand->hwEta() * 0.010875;
-  //if (fabs(simTrack.momentum().eta() - candGloablEta) < 0.3) //has no sense for displaced muons
+  //if (std::abs(simTrack.momentum().eta() - candGloablEta) < 0.3) //has no sense for displaced muons
   {
     double candGlobalPhi = omtfConfig->calcGlobalPhi(muonCand->hwPhi(), muonCand->processor());
     candGlobalPhi = hwGmtPhiToGlobalPhi(candGlobalPhi);
@@ -426,7 +428,7 @@ MatchingResult CandidateSimMuonMatcher::match(const l1t::RegionalMuonCand* muonC
     if (simTrack.momentum().pt() > 100)
       treshold = 20. * sigma;
 
-    if (fabs(result.deltaPhi - mean) < treshold && fabs(result.deltaEta) < 0.3)
+    if (std::abs(result.deltaPhi - mean) < treshold && std::abs(result.deltaEta) < 0.3)
       result.result = MatchingResult::ResultType::matched;
 
     LogTrace("l1tOmtfEventPrint") << "CandidateSimMuonMatcher::match: simTrack type " << simTrack.type() << " pt "
@@ -452,7 +454,7 @@ MatchingResult CandidateSimMuonMatcher::match(const l1t::RegionalMuonCand* muonC
   MatchingResult result(trackingParticle);
 
   double candGloablEta = muonCand->hwEta() * 0.010875;
-  //if (fabs(trackingParticle.momentum().eta() - candGloablEta) < 0.3)  //has no sense for displaced muons
+  //if (std::abs(trackingParticle.momentum().eta() - candGloablEta) < 0.3)  //has no sense for displaced muons
   {
     double candGlobalPhi = omtfConfig->calcGlobalPhi(muonCand->hwPhi(), muonCand->processor());
     candGlobalPhi = hwGmtPhiToGlobalPhi(candGlobalPhi);
@@ -487,7 +489,7 @@ MatchingResult CandidateSimMuonMatcher::match(const l1t::RegionalMuonCand* muonC
     if (trackingParticle.pt() > 100)
       treshold = 20. * sigma;
 
-    if (fabs(result.deltaPhi - mean) < treshold && fabs(result.deltaEta) < 0.3)
+    if (std::abs(result.deltaPhi - mean) < treshold && std::abs(result.deltaEta) < 0.3)
       result.result = MatchingResult::ResultType::matched;
 
     LogTrace("l1tOmtfEventPrint") << "CandidateSimMuonMatcher::match: trackingParticle type "
@@ -621,7 +623,7 @@ std::vector<MatchingResult> CandidateSimMuonMatcher::match(std::vector<const l1t
     //eta 0.7 is the beginning of the MB2,
     //the eta range wider than the nominal OMTF region is needed, as in any case muons outside this region are seen by the OMTF
     //so it better to train the nn suich that is able to measure its pt, as it may affect the rate
-    if ((fabs(tsof.globalPosition().eta()) >= 0.7) && (fabs(tsof.globalPosition().eta()) <= 1.31)) {
+    if ((std::abs(tsof.globalPosition().eta()) >= 0.7) && (std::abs(tsof.globalPosition().eta()) <= 1.31)) {
       LogTrace("l1tOmtfEventPrint")
           << "CandidateSimMuonMatcher::match simTrack IS in OMTF region, matching to the omtfCands";
     } else {
@@ -704,7 +706,7 @@ std::vector<MatchingResult> CandidateSimMuonMatcher::match(
 
     //checking if the propagated track is inside the OMTF range, TODO - tune the range!!!!!!!!!!!!!!!!!
     //eta 0.7 is the beginning of the MB2,
-    if ((fabs(tsof.globalPosition().eta()) >= 0.7) && (fabs(tsof.globalPosition().eta()) <= 1.3)) {
+    if ((std::abs(tsof.globalPosition().eta()) >= 0.7) && (std::abs(tsof.globalPosition().eta()) <= 1.3)) {
       LogTrace("l1tOmtfEventPrint")
           << "CandidateSimMuonMatcher::match trackingParticle IS in OMTF region, matching to the omtfCands";
     } else {

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/DataROOTDumper2.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/DataROOTDumper2.cc
@@ -36,7 +36,7 @@ DataROOTDumper2::DataROOTDumper2(const edm::ParameterSet& edmCfg,
     : EmulationObserverBase(edmCfg, omtfConfig), candidateSimMuonMatcher(candidateSimMuonMatcher) {
   edm::LogVerbatim("l1tOmtfEventPrint") << " omtfConfig->nTestRefHits() " << omtfConfig->nTestRefHits()
                                         << " event.omtfGpResultsPdfSum.num_elements() " << endl;
-  initializeTTree("dump.root");  //TODO
+  initializeTTree();
 
   if (edmCfg.exists("dumpKilledOmtfCands"))
     if (edmCfg.getParameter<bool>("dumpKilledOmtfCands"))
@@ -46,12 +46,10 @@ DataROOTDumper2::DataROOTDumper2(const edm::ParameterSet& edmCfg,
                                         << std::endl;
 }
 
-DataROOTDumper2::~DataROOTDumper2() { saveTTree(); }
+DataROOTDumper2::~DataROOTDumper2() {}
 
-void DataROOTDumper2::initializeTTree(std::string rootFileName) {
+void DataROOTDumper2::initializeTTree() {
   edm::Service<TFileService> fs;
-
-  //TFileDirectory subDir = fs->mkdir("OmtfDataDumper");
 
   rootTree = fs->make<TTree>("OMTFHitsTree", "");
 
@@ -95,8 +93,6 @@ void DataROOTDumper2::initializeTTree(std::string rootFileName) {
   ptGenNeg = fs->make<TH1I>("ptGenNeg", "ptGenNeg, eta at vertex 0.8 - 1.24", 400, 0, 200);
 }
 
-void DataROOTDumper2::saveTTree() {}
-
 void DataROOTDumper2::observeProcesorEmulation(unsigned int iProcessor,
                                                l1t::tftype mtfType,
                                                const std::shared_ptr<OMTFinput>&,
@@ -109,10 +105,10 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
   /*
   int muonCharge = 0;
   if (simMuon) {
-    if (fabs(simMuon->momentum().eta()) < 0.8 || fabs(simMuon->momentum().eta()) > 1.24)
+    if (std::abs(simMuon->momentum().eta()) < 0.8 || std::abs(simMuon->momentum().eta()) > 1.24)
       return;
 
-    muonCharge = (abs(simMuon->type()) == 13) ? simMuon->type() / -13 : 0;
+    muonCharge = (std::abs(simMuon->type()) == 13) ? simMuon->type() / -13 : 0;
     if (muonCharge > 0)
       ptGenPos->Fill(simMuon->momentum().pt());
     else
@@ -126,7 +122,7 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
   omtfEvent.muonEta = simMuon->momentum().eta();
 
   //TODO add cut on ete if needed
-    if(fabs(event.muonEta) < 0.8 || fabs(event.muonEta) > 1.24)
+    if(std::abs(event.muonEta) < 0.8 || std::abs(event.muonEta) > 1.24)
     return;
 
   omtfEvent.muonPhi = simMuon->momentum().phi();
@@ -151,7 +147,7 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
       omtfEvent.muonPhi = trackingParticle->momentum().phi();
       omtfEvent.muonPropEta = matchingResult.propagatedEta;
       omtfEvent.muonPropPhi = matchingResult.propagatedPhi;
-      omtfEvent.muonCharge = (abs(trackingParticle->pdgId()) == 13) ? trackingParticle->pdgId() / -13 : 0;
+      omtfEvent.muonCharge = (std::abs(trackingParticle->pdgId()) == 13) ? trackingParticle->pdgId() / -13 : 0;
 
       if (trackingParticle->parentVertex().isNonnull()) {
         omtfEvent.muonDxy = trackingParticle->dxy();
@@ -169,7 +165,7 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
                                     << " eta " << std::setw(9) << trackingParticle->momentum().eta() << " phi "
                                     << std::setw(9) << trackingParticle->momentum().phi() << std::endl;
 
-      if (fabs(omtfEvent.muonEta) > 0.8 && fabs(omtfEvent.muonEta) < 1.24) {
+      if (std::abs(omtfEvent.muonEta) > 0.8 && std::abs(omtfEvent.muonEta) < 1.24) {
         if (omtfEvent.muonCharge > 0)
           ptGenPos->Fill(omtfEvent.muonPt);
         else
@@ -205,7 +201,7 @@ void DataROOTDumper2::observeEventEnd(const edm::Event& iEvent,
                                     << " eta " << std::setw(9) << simTrack->momentum().eta() << " phi " << std::setw(9)
                                     << simTrack->momentum().phi() << std::endl;
 
-      if (fabs(omtfEvent.muonEta) > 0.8 && fabs(omtfEvent.muonEta) < 1.24) {
+      if (std::abs(omtfEvent.muonEta) > 0.8 && std::abs(omtfEvent.muonEta) < 1.24) {
         if (omtfEvent.muonCharge > 0)
           ptGenPos->Fill(omtfEvent.muonPt);
         else

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/EmulationObserverBase.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/EmulationObserverBase.cc
@@ -110,8 +110,8 @@ const std::vector<const reco::GenParticle*> EmulationObserverBase::findGenMuon(c
   for (size_t i = 0; i < genParticles->size(); ++i) {
     const reco::GenParticle& genPart = (*genParticles)[i];
 
-    if (abs(genPart.pdgId()) == 13) {
-      if (fabs(genPart.momentum().eta()) >= etaCutFrom && fabs(genPart.momentum().eta()) <= etaCutTo) {
+    if (std::abs(genPart.pdgId()) == 13) {
+      if (std::abs(genPart.momentum().eta()) >= etaCutFrom && std::abs(genPart.momentum().eta()) <= etaCutTo) {
         genPart.momentum().eta();
 
         muons.push_back(&genPart);

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/EventCapture.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/EventCapture.cc
@@ -59,7 +59,7 @@ void EventCapture::observeEventBegin(const edm::Event& event) {
     event.getByLabel(simTracksTag, simTraksHandle);
 
     for (unsigned int iSimTrack = 0; iSimTrack != simTraksHandle->size(); iSimTrack++) {
-      if (abs((*simTraksHandle.product())[iSimTrack].type()) == 13)
+      if (std::abs((*simTraksHandle.product())[iSimTrack].type()) == 13)
         simMuons.emplace_back(simTraksHandle, iSimTrack);
     }
   }
@@ -144,8 +144,8 @@ void EventCapture::observeEventEnd(const edm::Event& iEvent,
     bool wasSimMuInOmtfNeg = false;
     for (auto& simMuon : simMuons) {
       //TODO choose a condition, to print the desired events
-      if (simMuon->eventId().event() == 0 && fabs(simMuon->momentum().eta()) > 0.82 &&
-          fabs(simMuon->momentum().eta()) < 1.24 && simMuon->momentum().pt() >= 3.) {
+      if (simMuon->eventId().event() == 0 && std::abs(simMuon->momentum().eta()) > 0.82 &&
+          std::abs(simMuon->momentum().eta()) < 1.24 && simMuon->momentum().pt() >= 3.) {
         ostr << "SimMuon: eventId " << simMuon->eventId().event() << " pdgId " << std::setw(3) << simMuon->type()
              << " pt " << std::setw(9) << simMuon->momentum().pt()  //<<" Beta "<<simMuon->momentum().Beta()
              << " eta " << std::setw(9) << simMuon->momentum().eta() << " phi " << std::setw(9)
@@ -324,7 +324,7 @@ void EventCapture::observeEventEnd(const edm::Event& iEvent,
               << algoMuon->getGpResultUnconstr().getPhi()
               << ","
 
-              //<<std::setw(5)<<OMTFConfiguration::eta2Bits(abs(algoMuon->getEtaHw()))<<", "
+              //<<std::setw(5)<<OMTFConfiguration::eta2Bits(std::abs(algoMuon->getEtaHw()))<<", "
               << std::setw(5) << algoMuon->getEtaHw()
               << ", "
 
@@ -354,7 +354,7 @@ void EventCapture::observeEventEnd(const edm::Event& iEvent,
               << gbCandidate->getGpResultUnconstr().getPhi()
               << ","
 
-              //<<std::setw(5)<<OMTFConfiguration::eta2Bits(abs(gbCandidate->getEtaHw()))<<", "
+              //<<std::setw(5)<<OMTFConfiguration::eta2Bits(std::abs(gbCandidate->getEtaHw()))<<", "
               << std::setw(5) << gbCandidate->getEtaHw()
               << ", "
 
@@ -387,7 +387,7 @@ void EventCapture::observeEventEnd(const edm::Event& iEvent,
 
               ostr << "M" << iMu << ":" << std::setw(4) << finalCandidate.hwPt() << "," << std::setw(4)
                    << finalCandidate.hwQual() << "," << std::setw(4) << finalCandidate.hwPhi() << "," << std::setw(4)
-                   << abs(finalCandidate.hwEta())
+                   << std::abs(finalCandidate.hwEta())
                    << ","
                    //<<std::setw(10)<< finalCandidate.trackAddress().at(0)<<""
                    << std::setw(10) << trackAddr << "," << std::setw(4) << 0 << ","                 //Halo

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/PatternOptimizerBase.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/PatternOptimizerBase.cc
@@ -108,7 +108,7 @@ void PatternOptimizerBase::observeEventEnd(const edm::Event& iEvent,
     return;
 
   double ptSim = simMuon->momentum().pt();
-  int chargeSim = (abs(simMuon->type()) == 13) ? simMuon->type() / -13 : 0;
+  int chargeSim = (std::abs(simMuon->type()) == 13) ? simMuon->type() / -13 : 0;
 
   //double muDxy = (-1 * genMuon->vx() * genMuon->py() + genMuon->vy() * genMuon->px()) / genMuon->pt();;
 

--- a/L1Trigger/L1TMuonOverlapPhase1/src/Tools/StubsSimHitsMatching.cc
+++ b/L1Trigger/L1TMuonOverlapPhase1/src/Tools/StubsSimHitsMatching.cc
@@ -158,7 +158,7 @@ void StubsSimHitsMatcher::match(const edm::Event& iEvent,
                 auto strip = roll->strip(simHit.localPosition());
                 double simHitStripGlobalPhi = (roll->toGlobal(roll->centreOfStrip((int)strip))).phi();
 
-                if (fabs(stubGlobalPhi - simHitStripGlobalPhi) < 0.02) {
+                if (std::abs(stubGlobalPhi - simHitStripGlobalPhi) < 0.02) {
                   matchedTrackInfos.insert(MatchedTrackInfo(simHit.eventId().event(), simHit.trackId()));
                 }
 
@@ -185,7 +185,7 @@ void StubsSimHitsMatcher::match(const edm::Event& iEvent,
                 auto strip = rpcDigiSimLink.getStrip();
                 double simHitStripGlobalPhi = (roll->toGlobal(roll->centreOfStrip((int)strip))).phi();
 
-                if (fabs(stubGlobalPhi - simHitStripGlobalPhi) < 0.02) {
+                if (std::abs(stubGlobalPhi - simHitStripGlobalPhi) < 0.02) {
                   auto matchedTrackInfo = matchedTrackInfos.insert(
                       MatchedTrackInfo(rpcDigiSimLink.getEventId().event(), rpcDigiSimLink.getTrackId()));
                   matchedTrackInfo.first->matchedDigiCnt.at(iLogicLayer)++;
@@ -250,7 +250,7 @@ void StubsSimHitsMatcher::match(const edm::Event& iEvent,
                   LocalPoint point(wireX, 0, 0);
                   auto digiWireGlobal = layer->toGlobal(point);
 
-                  if (fabs(stubGlobalPhi - digiWireGlobal.phi()) < 0.03) {
+                  if (std::abs(stubGlobalPhi - digiWireGlobal.phi()) < 0.03) {
                     auto matchedTrackInfo = matchedTrackInfos.insert(
                         MatchedTrackInfo(dtDigiSimLink->eventId().event(), dtDigiSimLink->SimTrackId()));
                     matchedTrackInfo.first->matchedDigiCnt.at(iLogicLayer)++;
@@ -316,7 +316,7 @@ void StubsSimHitsMatcher::match(const edm::Event& iEvent,
                   auto strip = cscDigiSimLink.channel();
                   auto digiStripGlobalPhi = layer->centerOfStrip(strip).phi();
 
-                  if (fabs(stubGlobalPhi - digiStripGlobalPhi) < 0.03) {
+                  if (std::abs(stubGlobalPhi - digiStripGlobalPhi) < 0.03) {
                     auto matchedTrackInfo = matchedTrackInfos.insert(
                         MatchedTrackInfo(cscDigiSimLink.eventId().event(), cscDigiSimLink.SimTrackId()));
                     matchedTrackInfo.first->matchedDigiCnt.at(iLogicLayer)++;

--- a/L1Trigger/L1TMuonOverlapPhase2/interface/LutNetworkFixedPointRegression2Outputs.h
+++ b/L1Trigger/L1TMuonOverlapPhase2/interface/LutNetworkFixedPointRegression2Outputs.h
@@ -107,7 +107,6 @@ namespace lutNN {
           layer1OutWithBias;
       for (unsigned int i = 0; i < layer1Out.size(); i++) {
         layer1OutWithBias[i] = layer1Out[i] + layer1Bias;
-        //std::cout<<"i "<<i<<" layer1Out[i] "<<layer1Out[i]<<" layer1OutWithBias "<<i<<" "<<layer1OutWithBias[i]<<" layer1Bias "<<layer1Bias<<std::dec<<std::endl;
       }
 
       lutLayer2.runWithInterpolation(layer1OutWithBias);
@@ -132,12 +131,10 @@ namespace lutNN {
       }
 
       unsigned int bias = (noHitsCnt << noHitCntShift);
-      //std::cout<<" noHitsCnt "<<noHitsCnt<<" event->noHitVal "<<event->noHitVal<<" bias "<<std::hex<<"0x"<<bias<<std::dec<<std::endl;
 
       //layer1Bias switches the input of the layer2 (i.e. output of the layer1) do different regions in the LUTs
       //depending on the  number of layers without hits
       layer1Bias = bias;
-      //std::cout<<"layer1Bias "<<layer1Bias<<" W "<<layer1Bias.width <<std::endl;
 
       runWithInterpolation();
 
@@ -146,8 +143,6 @@ namespace lutNN {
       //auto layer3_1_out = ap_fixed <output1_I+output1_F, output1_I, AP_RND_CONV, AP_SAT>(lutLayer3_1.getLutOutSum()[0]); //here layer3_0_out has size 1
       auto layer3_0_out = lutLayer3_0.getLutOutSum()[0];  //here layer3_0_out has size 1
       auto layer3_1_out = lutLayer3_1.getLutOutSum()[0];  //here layer3_0_out has size 1
-
-      //std::cout<<"layer3_0_out[0] "<<layer3_0_out[0]<<" layer3_1_out[0] "<<layer3_1_out[0]<<std::endl;
 
       nnResult[0] = layer3_0_out.to_float();
       nnResult[1] = layer3_1_out.to_float();
@@ -183,7 +178,6 @@ namespace lutNN {
       PUT_VAR(tree, key, size)
       std::ostringstream ostr;
       for (auto& a : ptCalibrationArray) {
-        //ostr<<std::hex<<a.to_uint()<<", ";
         ostr << a.to_uint() << ", ";
       }
       tree.put(key + ".values", ostr.str());
@@ -221,7 +215,6 @@ namespace lutNN {
 
       for (auto& a : ptCalibrationArray) {
         if (std::getline(ss, item, ',')) {
-          //a = std::stoul(item, nullptr, 16);
           a = std::stoul(item, nullptr, 10);
         } else {
           throw std::runtime_error(

--- a/L1Trigger/L1TMuonOverlapPhase2/src/OmtfEmulation.cc
+++ b/L1Trigger/L1TMuonOverlapPhase2/src/OmtfEmulation.cc
@@ -13,6 +13,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include <memory>
+
 OmtfEmulation::OmtfEmulation(const edm::ParameterSet& edmParameterSet,
                              MuStubsInputTokens& muStubsInputTokens,
                              edm::EDGetTokenT<L1Phase2MuDTPhContainer> inputTokenDTPhPhase2)


### PR DESCRIPTION
This PR contains partial cleaning to fulfill `code-checks` (CLANG) and `code-format` rules.
Additionally configuration of OMTF emulator with extrapolation inherits from base configuration without the extrapolation.

Please check if the changes are fine. If so, merge them. Then, I will port this to CMSSW master (14_0_X), split on phase1 and phase2 parts and prepare a PRs to official CMSSW for phase1 and to phase2-integration branch for phase1 and phase2 changes. 

I suppose that additional cleaning will be requested during integration process as there is still some amount of commented out code used for tests that is not well seen in production version.

This is second trial of #8 (which will be closed) after integrating developments from the base branch (developments were not big, but integration was painful). Please check it ASAP and give me GL to PRs.

FYI, @akalinow
